### PR TITLE
feat: engagement reaction push

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -19,7 +19,7 @@ type subAdapter struct {
 func New(cfg *config.Config, l logger.Logger) IAdapter {
 	return &Adapter{
 		subAdapter: subAdapter{
-			Fortress: fortress.New(cfg.Endpoint.Fortress),
+			Fortress: fortress.New(cfg.Endpoint.Fortress, cfg.ApiServer.APIKey),
 			Mochi:    mochi.New(cfg.Endpoint.Mochi),
 		},
 	}

--- a/pkg/adapter/fortress/fortress.go
+++ b/pkg/adapter/fortress/fortress.go
@@ -376,3 +376,28 @@ func (f *Fortress) SendChangelog(c *model.Changelog) error {
 
 	return nil
 }
+
+func (f *Fortress) UpsertRollupRecord(record *model.EngagementsRollupRecord) error {
+	jsonValue, err := json.Marshal(record)
+	req, err := f.makeReq("/api/v1/engagements/rollup", http.MethodPost, bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errMsg ErrorMessage
+		if err := json.NewDecoder(resp.Body).Decode(&errMsg); err != nil {
+			return errors.New("invalid decoded, error " + err.Error())
+		}
+		return errors.New("invalid call, code " + strconv.Itoa(resp.StatusCode) + " " + errMsg.Message)
+	}
+
+	return nil
+}

--- a/pkg/adapter/fortress/interface.go
+++ b/pkg/adapter/fortress/interface.go
@@ -28,4 +28,6 @@ type FortressAdapter interface {
 
 	GetChangelogs() (digests *model.ChangelogDigest, err error)
 	SendChangelog(changelog *model.Changelog) error
+
+	UpsertRollupRecord(record *model.EngagementsRollupRecord) error
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type DiscordIds struct {
 }
 
 type ApiServer struct {
+	APIKey         string
 	Port           string
 	AllowedOrigins string
 }
@@ -51,7 +52,8 @@ func Generate(v ENV) *Config {
 		Debug: v.GetBool("DEBUG"),
 		Env:   v.GetString("ENV"),
 		ApiServer: ApiServer{
-			Port: v.GetString("PORT"),
+			Port:   v.GetString("PORT"),
+			APIKey: v.GetString("FORTRESS_API_KEY"),
 		},
 		Endpoint: Endpoint{
 			Fortress: v.GetString("FORTRESS_ENDPOINT"),

--- a/pkg/discord/command/command.go
+++ b/pkg/discord/command/command.go
@@ -33,6 +33,7 @@ type Command struct {
 	L    logger.Logger
 	Cmds map[string]base.TextCommander
 	View view.Viewer
+	S    service.Servicer
 }
 
 func New(cfg *config.Config, l logger.Logger, svc service.Servicer, view view.Viewer, msgHistory *history.MsgHistory) *Command {
@@ -40,6 +41,7 @@ func New(cfg *config.Config, l logger.Logger, svc service.Servicer, view view.Vi
 		Cmds: make(map[string]base.TextCommander),
 		L:    l,
 		View: view,
+		S:    svc,
 	}
 
 	// register all commands here

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -43,6 +43,8 @@ func (d *Discord) ListenAndServe() (*discordgo.Session, error) {
 	// register interaction, right now use for sending updates
 	d.Session.AddHandler(d.onInteractionCreate)
 	d.Session.AddHandler(d.onReactionCreate)
+	d.Session.AddHandler(d.onReactionRemove)
+	d.Session.AddHandler(d.onAllReactionsRemove)
 
 	// intents to receive message
 	d.Session.Identify.Intents = discordgo.IntentsGuildMessages |

--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -2,7 +2,6 @@ package discord
 
 import (
 	"github.com/bwmarrin/discordgo"
-
 	"github.com/dwarvesf/fortress-discord/pkg/config"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/command"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/history"
@@ -43,9 +42,11 @@ func (d *Discord) ListenAndServe() (*discordgo.Session, error) {
 
 	// register interaction, right now use for sending updates
 	d.Session.AddHandler(d.onInteractionCreate)
+	d.Session.AddHandler(d.onReactionCreate)
 
 	// intents to receive message
-	d.Session.Identify.Intents = discordgo.IntentsGuildMessages
+	d.Session.Identify.Intents = discordgo.IntentsGuildMessages |
+		discordgo.IntentsGuildMessageReactions
 
 	err := d.Session.Open()
 	if err != nil {

--- a/pkg/discord/interaction_listener.go
+++ b/pkg/discord/interaction_listener.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/k0kubun/pp"
 )
 
 // TODO: generics this to specific packages
@@ -55,9 +54,8 @@ func (d *Discord) onInteractionCreate(s *discordgo.Session, i *discordgo.Interac
 		}
 		url = fmt.Sprintf(url, strings.Replace(i.MessageComponentData().Values[0], "-", "", -1))
 
-		pp.Println(url)
-
 		req, _ := http.NewRequest("POST", url, nil)
+		req.Header.Set("Authorization", "ApiKey "+d.Cfg.ApiServer.APIKey)
 		req.Header.Set("Content-Type", "application/json")
 
 		client := &http.Client{}

--- a/pkg/discord/listener.go
+++ b/pkg/discord/listener.go
@@ -103,5 +103,35 @@ func (d *Discord) onReactionCreate(s *discordgo.Session, m *discordgo.MessageRea
 		l.Error(err, "unable to upsert record")
 		return
 	}
-	l.Info("counted new reaction")
+	l.Info("increased reaction count")
+}
+
+func (d *Discord) onReactionRemove(s *discordgo.Session, m *discordgo.MessageReactionRemove) {
+	channel, err := s.Channel(m.ChannelID)
+	if err != nil {
+		l := d.L.AddField("channelID", m.ChannelID)
+		l.Error(err, "unable to get channel")
+		return
+	}
+	record := &model.EngagementsRollupRecord{
+		DiscordUserID: m.UserID,
+		LastMessageID: m.MessageID,
+		ChannelID:     channel.ID,
+		CategoryID:    channel.ParentID,
+		MessageCount:  0,
+		ReactionCount: -1,
+	}
+	l := d.L.AddField("record", record)
+	err = d.Command.S.Engagement().UpsertRollup(record)
+	if err != nil {
+		l.Error(err, "unable to upsert record")
+		return
+	}
+	l.Info("decreased reaction count")
+}
+
+func (d *Discord) onAllReactionsRemove(s *discordgo.Session, m *discordgo.MessageReactionRemoveAll) {
+	// TODO: implement this
+	// it seems impossible to handle this correctly, since discord.MessageReactionRemoveAll
+	// does not include the number of reactions removed
 }

--- a/pkg/discord/listener.go
+++ b/pkg/discord/listener.go
@@ -24,7 +24,7 @@ func (d *Discord) onMessageCreate(s *discordgo.Session, m *discordgo.MessageCrea
 	// add "is typing" indicator
 	d.Session.ChannelTyping(m.ChannelID)
 
-	// pipetrhough message to command
+	// pipethrough message to command
 	err := d.Command.Execute(d.parseMessage(m))
 	if err != nil {
 		d.L.Error(err, "failed to execute command")

--- a/pkg/discord/service/engagement/engagement.go
+++ b/pkg/discord/service/engagement/engagement.go
@@ -1,0 +1,29 @@
+package engagement
+
+import (
+	"github.com/dwarvesf/fortress-discord/pkg/adapter"
+	"github.com/dwarvesf/fortress-discord/pkg/logger"
+	"github.com/dwarvesf/fortress-discord/pkg/model"
+)
+
+type Engagement struct {
+	a adapter.IAdapter
+	l logger.Logger
+}
+
+func New(a adapter.IAdapter, l logger.Logger) EngagementServicer {
+	return &Engagement{
+		a: a,
+		l: l,
+	}
+}
+
+func (e *Engagement) UpsertRollup(record *model.EngagementsRollupRecord) error {
+	err := e.a.Fortress().UpsertRollupRecord(record)
+	if err != nil {
+		e.l.Error(err, "upsert rollup record error")
+		return err
+	}
+
+	return nil
+}

--- a/pkg/discord/service/engagement/interface.go
+++ b/pkg/discord/service/engagement/interface.go
@@ -1,0 +1,7 @@
+package engagement
+
+import "github.com/dwarvesf/fortress-discord/pkg/model"
+
+type EngagementServicer interface {
+	UpsertRollup(record *model.EngagementsRollupRecord) error
+}

--- a/pkg/discord/service/interface.go
+++ b/pkg/discord/service/interface.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/changelog"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/digest"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/earn"
+	"github.com/dwarvesf/fortress-discord/pkg/discord/service/engagement"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/event"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/hiring"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/issue"
@@ -28,4 +29,5 @@ type Servicer interface {
 	Memo() memo.MemoServicer
 	Treasury() treasury.TreasuryServicer
 	Issue() issue.IssueServicer
+	Engagement() engagement.EngagementServicer
 }

--- a/pkg/discord/service/service.go
+++ b/pkg/discord/service/service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/changelog"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/digest"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/earn"
+	"github.com/dwarvesf/fortress-discord/pkg/discord/service/engagement"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/event"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/hiring"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service/issue"
@@ -34,6 +35,7 @@ type subService struct {
 	Treasury   treasury.TreasuryServicer
 	Issue      issue.IssueServicer
 	Changelog  changelog.ChangelogServicer
+	Engagement engagement.EngagementServicer
 }
 
 func New(adapter adapter.IAdapter, l logger.Logger) Servicer {
@@ -51,6 +53,7 @@ func New(adapter adapter.IAdapter, l logger.Logger) Servicer {
 			Treasury:   treasury.New(adapter, l),
 			Issue:      issue.New(adapter, l),
 			Changelog:  changelog.New(adapter, l),
+			Engagement: engagement.New(adapter, l),
 		},
 	}
 }
@@ -101,4 +104,8 @@ func (s *Service) Issue() issue.IssueServicer {
 
 func (s *Service) Changelog() changelog.ChangelogServicer {
 	return s.subService.Changelog
+}
+
+func (s *Service) Engagement() engagement.EngagementServicer {
+	return s.subService.Engagement
 }

--- a/pkg/model/engagements_rollup.go
+++ b/pkg/model/engagements_rollup.go
@@ -1,0 +1,10 @@
+package model
+
+type EngagementsRollupRecord struct {
+	DiscordUserID string `json:"discordUserID"`
+	LastMessageID string `json:"lastMessageID"`
+	ChannelID     string `json:"channelID"`
+	CategoryID    string `json:"categoryID"`
+	MessageCount  int    `json:"messageCount"`
+	ReactionCount int    `json:"reactionCount"`
+}


### PR DESCRIPTION
#### What's this PR do?

- [x] Add handling `MessageReactionAdd`
- [x] Add handling `MessageReactionRemove`
- [x] Implement service
- [x] Implement adapter

#### What are the relevant Git tickets?

https://github.com/dwarvesf/fortress-api/pull/578

#### Screenshots (if appropriate)

None

#### Any background context you want to provide? (if appropriate)

- Push interaction is needed since Discord's official API does not provide a reliable way to pull reaction's author
- Relevant Notion task: https://www.notion.so/dwarves/Discord-Engagement-Metrics-Collect-7da7aa955d7a45cf8cdee20f6f157b67
