### PR TITLE
fix: add channel restriction for cmd icy accounting

### DIFF
--- a/pkg/discord/command/command.go
+++ b/pkg/discord/command/command.go
@@ -66,7 +66,7 @@ func New(cfg *config.Config, l logger.Logger, svc service.Servicer, view view.Vi
 		help.New(l, svc, view),
 		hiring.New(l, svc, view),
 		hold.New(l, svc, view),
-		icy.New(l, svc, view),
+		icy.New(l, svc, view, cfg),
 		index.New(l, svc, view),
 		issue.New(l, svc, view),
 		memo.New(l, svc, view),

--- a/pkg/discord/command/icy/base.go
+++ b/pkg/discord/command/icy/base.go
@@ -21,6 +21,9 @@ func (e *Icy) Execute(message *model.DiscordMessage) error {
 	case "list":
 		return e.List(message)
 	case "accounting":
+		if !e.ChannelPermissionCheck(message) {
+			return e.view.Error().Raise(message, "This command is not allowed in this channel.")
+		}
 		return e.Accounting(message)
 	}
 
@@ -39,11 +42,20 @@ func (e *Icy) DefaultCommand(message *model.DiscordMessage) error {
 	return e.List(message)
 }
 
-func (u *Icy) PermissionCheck(message *model.DiscordMessage) (bool, []string) {
+func (e *Icy) PermissionCheck(message *model.DiscordMessage) (bool, []string) {
 	switch message.ContentArgs[1] {
 	case "accounting":
 		return permutil.CheckSmodOrAbove(message.Roles)
 	}
 
 	return true, []string{}
+}
+
+func (e *Icy) ChannelPermissionCheck(message *model.DiscordMessage) bool {
+	switch message.ContentArgs[1] {
+	case "accounting":
+		return permutil.CheckWhitelistChannels(e.cfg.Discord.WhiteListedChannels, message.ChannelId)
+	}
+
+	return true
 }

--- a/pkg/discord/command/icy/icy.go
+++ b/pkg/discord/command/icy/icy.go
@@ -1,6 +1,7 @@
 package icy
 
 import (
+	"github.com/dwarvesf/fortress-discord/pkg/config"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/service"
 	"github.com/dwarvesf/fortress-discord/pkg/discord/view"
 	"github.com/dwarvesf/fortress-discord/pkg/logger"
@@ -11,13 +12,15 @@ type Icy struct {
 	L    logger.Logger
 	svc  service.Servicer
 	view view.Viewer
+	cfg  *config.Config
 }
 
-func New(l logger.Logger, svc service.Servicer, view view.Viewer) EarnCommander {
+func New(l logger.Logger, svc service.Servicer, view view.Viewer, cfg *config.Config) EarnCommander {
 	return &Icy{
 		L:    l,
 		svc:  svc,
 		view: view,
+		cfg:  cfg,
 	}
 }
 

--- a/pkg/utils/permutil/channel.go
+++ b/pkg/utils/permutil/channel.go
@@ -1,0 +1,14 @@
+package permutil
+
+import "strings"
+
+func CheckWhitelistChannels(whiteListedChannelsString string, channelId string) bool {
+	whiteListedChannels := strings.Split(whiteListedChannelsString, ",")
+
+	for _, id := range whiteListedChannels {
+		if channelId == strings.TrimSpace(id) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#### What's this PR do?

Add channel restriction for cmd icy accounting

<img width="373" alt="image" src="https://github.com/dwarvesf/fortress-discord/assets/32956772/ad8f6644-de79-427a-a61c-4da71e138ba5">
