### PR TITLE
feat: icy personal info cmd

### DIFF
--- a/pkg/adapter/fortress/fortress.go
+++ b/pkg/adapter/fortress/fortress.go
@@ -800,3 +800,53 @@ func (f *Fortress) GetIcyAccounting() (icyAccounting *model.AdapterIcyAccounting
 
 	return icyAccounting, nil
 }
+
+func (f *Fortress) ListICYEarnedTransactions(discordID string, page, size int) (*model.AdapterICYEarnedTransactions, error) {
+	req, err := f.makeReq(fmt.Sprintf("/api/v1/discords/%s/earns/transactions?page=%d&size=%d", discordID, page, size), http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid call, code %v", resp.StatusCode)
+	}
+
+	var transactions model.AdapterICYEarnedTransactions
+	if err := json.NewDecoder(resp.Body).Decode(&transactions); err != nil {
+		return nil, fmt.Errorf("invalid decoded, error %v", err.Error())
+	}
+
+	return &transactions, nil
+}
+
+func (f *Fortress) GetICYTotalEarned(discordID string) (*model.AdapterICYTotalEarned, error) {
+	req, err := f.makeReq(fmt.Sprintf("/api/v1/discords/%s/earns/total", discordID), http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid call, code %v", resp.StatusCode)
+	}
+
+	var total model.AdapterICYTotalEarned
+	if err := json.NewDecoder(resp.Body).Decode(&total); err != nil {
+		return nil, fmt.Errorf("invalid decoded, error %v", err.Error())
+	}
+
+	return &total, nil
+}

--- a/pkg/adapter/fortress/interface.go
+++ b/pkg/adapter/fortress/interface.go
@@ -49,4 +49,6 @@ type FortressAdapter interface {
 
 	SalaryAdvanceReport() (unpaidSalaryAdvances *model.AdapterSalaryAdvanceReport, err error)
 	GetIcyAccounting() (icyAccounting *model.AdapterIcyAccounting, err error)
+	ListICYEarnedTransactions(discordID string, page, size int) (*model.AdapterICYEarnedTransactions, error)
+	GetICYTotalEarned(discordID string) (*model.AdapterICYTotalEarned, error)
 }

--- a/pkg/discord/command/icy/base.go
+++ b/pkg/discord/command/icy/base.go
@@ -39,10 +39,14 @@ func (e *Icy) Help(message *model.DiscordMessage) error {
 }
 
 func (e *Icy) DefaultCommand(message *model.DiscordMessage) error {
-	return e.List(message)
+	return e.PersonalInfo(message)
 }
 
 func (e *Icy) PermissionCheck(message *model.DiscordMessage) (bool, []string) {
+	if len(message.ContentArgs) == 1 {
+		return true, []string{}
+	}
+
 	switch message.ContentArgs[1] {
 	case "accounting":
 		return permutil.CheckSmodOrAbove(message.Roles)
@@ -52,6 +56,10 @@ func (e *Icy) PermissionCheck(message *model.DiscordMessage) (bool, []string) {
 }
 
 func (e *Icy) ChannelPermissionCheck(message *model.DiscordMessage) bool {
+	if len(message.ContentArgs) == 1 {
+		return true
+	}
+
 	switch message.ContentArgs[1] {
 	case "accounting":
 		return permutil.CheckWhitelistChannels(e.cfg.Discord.WhiteListedChannels, message.ChannelId)

--- a/pkg/discord/command/icy/icy.go
+++ b/pkg/discord/command/icy/icy.go
@@ -15,7 +15,7 @@ type Icy struct {
 	cfg  *config.Config
 }
 
-func New(l logger.Logger, svc service.Servicer, view view.Viewer, cfg *config.Config) EarnCommander {
+func New(l logger.Logger, svc service.Servicer, view view.Viewer, cfg *config.Config) IcyCommander {
 	return &Icy{
 		L:    l,
 		svc:  svc,
@@ -54,4 +54,31 @@ func (e *Icy) Accounting(message *model.DiscordMessage) error {
 
 	// 2. render
 	return e.view.Icy().Accounting(message, icyAccounting, report)
+}
+
+func (e *Icy) PersonalInfo(message *model.DiscordMessage) error {
+	// 1. get data from service
+	// 1.1 Get icy accounting info
+	icyAccounting, err := e.svc.Icy().GetIcyAccounting()
+	if err != nil {
+		e.L.Error(err, "can't get icy accounting info")
+		return err
+	}
+
+	// 1.2 Get total icy earned
+	totalEarned, err := e.svc.Icy().GetICYTotalEarned(message.Author.ID)
+	if err != nil {
+		e.L.Error(err, "can't get total icy earned")
+		return err
+	}
+
+	// 1.3 Get list last 5 icy transactions
+	earnedTxns, err := e.svc.Icy().ListICYEarnedTransactions(message.Author.ID, 0, 5)
+	if err != nil {
+		e.L.Error(err, "can't get list of last 5 icy transactions")
+		return err
+	}
+
+	// 2. render
+	return e.view.Icy().PersonalInfo(message, icyAccounting, totalEarned, earnedTxns)
 }

--- a/pkg/discord/command/icy/interface.go
+++ b/pkg/discord/command/icy/interface.go
@@ -5,7 +5,7 @@ import (
 	"github.com/dwarvesf/fortress-discord/pkg/model"
 )
 
-type EarnCommander interface {
+type IcyCommander interface {
 	base.TextCommander
 
 	List(message *model.DiscordMessage) error

--- a/pkg/discord/service/icy/icy.go
+++ b/pkg/discord/service/icy/icy.go
@@ -55,3 +55,25 @@ func (e *Icy) GetIcyAccounting() (*model.IcyAccounting, error) {
 	// normalized into in-app model
 	return icyAccounting.Data, nil
 }
+
+func (e *Icy) ListICYEarnedTransactions(discordID string, page, size int) ([]*model.ICYEarnedTransaction, error) {
+	// get response from fortress
+	transactions, err := e.adapter.Fortress().ListICYEarnedTransactions(discordID, page, size)
+	if err != nil {
+		e.l.Error(err, "can't get list icy earned transactions")
+		return nil, err
+	}
+
+	return transactions.Data, nil
+}
+
+func (e *Icy) GetICYTotalEarned(discordID string) (*model.ICYTotalEarned, error) {
+	// get response from fortress
+	total, err := e.adapter.Fortress().GetICYTotalEarned(discordID)
+	if err != nil {
+		e.l.Error(err, "can't get icy total earned")
+		return nil, err
+	}
+
+	return total.Data, nil
+}

--- a/pkg/discord/service/icy/interface.go
+++ b/pkg/discord/service/icy/interface.go
@@ -6,4 +6,6 @@ type IcyServicer interface {
 	GetWeeklyDistribution() ([]*model.Icy, error)
 	ListUnpaidSalaryAdvances() (*model.SalaryAdvanceReport, error)
 	GetIcyAccounting() (*model.IcyAccounting, error)
+	ListICYEarnedTransactions(discordID string, page, size int) ([]*model.ICYEarnedTransaction, error)
+	GetICYTotalEarned(discordID string) (*model.ICYTotalEarned, error)
 }

--- a/pkg/discord/view/icy/accounting.go
+++ b/pkg/discord/view/icy/accounting.go
@@ -11,16 +11,6 @@ import (
 	"github.com/dwarvesf/fortress-discord/pkg/utils/cryptoutils"
 )
 
-const (
-	discordEmojiAccountingIceCube        = ":ice_cube:"
-	discordEmojiAccountingDollar         = ":dollar:"
-	discordEmojiAccountingTitle          = "<:pepenote:885515949673951282>"
-	discordEmojiAccountingContractFund   = "<:pepeMoney:1086173791329210388>"
-	discordEmojiAccountingCirculatingICY = "<:anxinicy:1014483263705862174>"
-	discordEmojiAccountingOffsetUSDT     = "<:anxin:973799916147179550>"
-	discordEmojiAccountingUnpaid         = "<:pepebusiness:885513213687504936>"
-)
-
 func (e *Icy) Accounting(original *model.DiscordMessage, icyAccounting *model.IcyAccounting, report *model.SalaryAdvanceReport) error {
 	if original == nil || icyAccounting == nil || icyAccounting.ICY == nil || icyAccounting.USDT == nil || report == nil {
 		return nil
@@ -40,15 +30,15 @@ func (e *Icy) Accounting(original *model.DiscordMessage, icyAccounting *model.Ic
 	}
 
 	contentLines := []string{
-		fmt.Sprintf("%s `Contract Fund.   `%s **%s USDT**", discordEmojiAccountingContractFund, discordEmojiAccountingDollar, formattedContractFund),
-		fmt.Sprintf("%s `Circulating ICY. `%s **%s ICY**", discordEmojiAccountingCirculatingICY, discordEmojiAccountingIceCube, formattedCirculatingICY),
-		fmt.Sprintf("%s `Offset USDT.     `%s **%s USDT**", discordEmojiAccountingOffsetUSDT, discordEmojiAccountingDollar, formattedOffsetUSDT),
+		fmt.Sprintf("%s `Contract Fund.   `%s **%s USDT**", discordEmojiPepeMoney, discordEmojiDollar, formattedContractFund),
+		fmt.Sprintf("%s `Circulating ICY. `%s **%s ICY**", discordEmojiAnxinICY, discordEmojiIceCube, formattedCirculatingICY),
+		fmt.Sprintf("%s `Offset USDT.     `%s **%s USDT**", discordEmojiAnxin, discordEmojiDollar, formattedOffsetUSDT),
 		"",
-		fmt.Sprintf("%s **Unpaid Salary Advances** - %s `%d ICY`", discordEmojiAccountingUnpaid, discordEmojiAccountingIceCube, report.TotalICY),
+		fmt.Sprintf("%s **Unpaid Salary Advances** - %s `%d ICY`", discordEmojiPepeBusiness, discordEmojiIceCube, report.TotalICY),
 	}
 
 	for i, advance := range report.SalaryAdvances {
-		contentLines = append(contentLines, fmt.Sprintf("%d. <@%s> - %s `%d ICY`", i, advance.DiscordID, discordEmojiAccountingIceCube, advance.AmountICY))
+		contentLines = append(contentLines, fmt.Sprintf("%d. <@%s> - %s `%d ICY`", i, advance.DiscordID, discordEmojiIceCube, advance.AmountICY))
 	}
 
 	if icyAccounting.ICY.Address != "" {
@@ -57,7 +47,7 @@ func (e *Icy) Accounting(original *model.DiscordMessage, icyAccounting *model.Ic
 	}
 
 	msg := &discordgo.MessageEmbed{
-		Title:       fmt.Sprintf("%s ICY Accounting", discordEmojiAccountingTitle),
+		Title:       fmt.Sprintf("%s ICY Accounting", discordEmojiPepeNote),
 		Description: strings.Join(contentLines, "\n"),
 	}
 

--- a/pkg/discord/view/icy/emoji.go
+++ b/pkg/discord/view/icy/emoji.go
@@ -1,0 +1,17 @@
+package icy
+
+const (
+	discordEmojiIceCube          = ":ice_cube:"
+	discordEmojiDollar           = ":dollar:"
+	discordEmojiPepeNote         = "<:pepenote:885515949673951282>"
+	discordEmojiPepeMoney        = "<:pepeMoney:1086173791329210388>"
+	discordEmojiAnxinICY         = "<:anxinicy:1014483263705862174>"
+	discordEmojiAnxin            = "<:anxin:973799916147179550>"
+	discordEmojiPepeBusiness     = "<:pepebusiness:885513213687504936>"
+	discordEmojiPepeWhale        = "<:pepewhale:902558994437144646>"
+	discordEmojiIceToken         = ":ICY:"
+	discordEmojiPepeStonk        = ":pepestonk:"
+	discordEmojiPepeAhegao       = ":pepeahegao:"
+	discordEmojiPepeCoolNerd     = ":pepecoolnerd: "
+	discordEmojiSmallBlueDiamond = ":small_blue_diamond:"
+)

--- a/pkg/discord/view/icy/info.go
+++ b/pkg/discord/view/icy/info.go
@@ -1,0 +1,82 @@
+package icy
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/dwarvesf/fortress-discord/pkg/discord/view/base"
+	"github.com/dwarvesf/fortress-discord/pkg/model"
+	"github.com/dwarvesf/fortress-discord/pkg/utils/cryptoutils"
+)
+
+func (e *Icy) PersonalInfo(original *model.DiscordMessage, accounting *model.IcyAccounting, totalEarned *model.ICYTotalEarned, earnedTxns []*model.ICYEarnedTransaction) error {
+	if original == nil || accounting == nil || accounting.ICY == nil || accounting.USDT == nil || totalEarned == nil || earnedTxns == nil {
+		return nil
+	}
+
+	var formattedContractFund string = "NaN"
+	if fund := cryptoutils.StringBigIntToStringCurrency(accounting.ContractFundInUSDT, accounting.USDT.Decimals); fund != "" {
+		formattedContractFund = fund
+	}
+
+	last5Txns := [][]string{}
+	last5Msgs := []string{}
+	for _, txn := range earnedTxns {
+		if txn == nil || txn.Token == nil {
+			continue
+		}
+
+		var amountICY string = "NaN"
+		if amount := cryptoutils.StringBigIntToStringCurrency(txn.Amount, int(txn.Token.Decimal)); amount != "" {
+			amountICY = amount
+		}
+
+		var amountUSDT string = "NaN"
+		if amount := cryptoutils.StringBigIntToStringCurrency(big.NewFloat(txn.USDAmount).String(), 0); amount != "" {
+			amountUSDT = amount
+		}
+
+		msg, _ := txn.Metadata["message"].(string)
+		last5Msgs = append(last5Msgs, msg)
+
+		last5Txns = append(last5Txns, []string{
+			formatTimeAgo(txn.CreatedAt),
+			txn.ExternalID[:4],
+			fmt.Sprintf("%s ICY", amountICY),
+			fmt.Sprintf("%s USDT", amountUSDT),
+		})
+	}
+
+	txnsTable := formatTable(last5Txns, last5Msgs)
+
+	contentLines := []string{
+		// ICY Address
+		fmt.Sprintf("%s **ICY Address**", discordEmojiPepeStonk),
+		fmt.Sprintf("`%s|%s`", strings.ToUpper(accounting.ICY.Chain), accounting.ICY.Address),
+		"",
+		// ICY conversion rate
+		fmt.Sprintf("%s **Conversion Rate**", discordEmojiPepeAhegao),
+		fmt.Sprintf("%s`1 ICY` ~ %s`%.1f USDT`", discordEmojiIceCube, discordEmojiDollar, accounting.ConversionRate),
+		"",
+		// Contract Fund
+		fmt.Sprintf("%s **Contract Fund**", discordEmojiPepeMoney),
+		fmt.Sprintf("%s`%s USDT`", discordEmojiDollar, formattedContractFund),
+		"",
+		// Your Earned ICY
+		fmt.Sprintf("%s **Your Earned ICY**", discordEmojiPepeCoolNerd),
+		fmt.Sprintf("%s`%s ICY` ~ %s`%d USDT`", discordEmojiIceCube, totalEarned.TotalEarnsICY, discordEmojiDollar, totalEarned.TotalEarnsUSD),
+		"",
+		// Your Last 5 Transactions
+		fmt.Sprintf("%s **Your Last 5 Earns**", discordEmojiAnxinICY),
+		txnsTable,
+	}
+
+	msg := &discordgo.MessageEmbed{
+		Title:       fmt.Sprintf("%s Your ICY Discovery", discordEmojiPepeWhale),
+		Description: strings.Join(contentLines, "\n"),
+	}
+
+	return base.SendEmbededMessage(e.ses, original, msg)
+}

--- a/pkg/discord/view/icy/interface.go
+++ b/pkg/discord/view/icy/interface.go
@@ -5,5 +5,6 @@ import "github.com/dwarvesf/fortress-discord/pkg/model"
 type IcyViewer interface {
 	List(original *model.DiscordMessage, earns []*model.Icy) error
 	Accounting(original *model.DiscordMessage, icyAccounting *model.IcyAccounting, report *model.SalaryAdvanceReport) error
+	PersonalInfo(original *model.DiscordMessage, accounting *model.IcyAccounting, totalEarned *model.ICYTotalEarned, earnedTxns []*model.ICYEarnedTransaction) error
 	Help() error
 }

--- a/pkg/discord/view/icy/utils.go
+++ b/pkg/discord/view/icy/utils.go
@@ -1,0 +1,72 @@
+package icy
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func formatTimeAgo(t time.Time) string {
+	duration := time.Since(t)
+
+	if duration.Seconds() < 60 {
+		return fmt.Sprintf("%.0fs ago", duration.Seconds())
+	} else if duration.Minutes() < 60 {
+		return fmt.Sprintf("%.0fm ago", duration.Minutes())
+	} else if duration.Hours() < 24 {
+		return fmt.Sprintf("%.0fh ago", duration.Hours())
+	} else if duration.Hours() < 720 {
+		return fmt.Sprintf("%.0fd ago", duration.Hours()/24)
+	} else {
+		return fmt.Sprintf("%.0fM ago", duration.Hours()/720)
+	}
+}
+
+// calculatePadding calculates the padding required for each column
+func calculatePadding(data [][]string) []int {
+	numCols := len(data[0])
+	padLengths := make([]int, numCols)
+
+	for _, row := range data {
+		for i, col := range row {
+			colLength := len(col)
+			if colLength > padLengths[i] {
+				padLengths[i] = colLength
+			}
+		}
+	}
+
+	return padLengths
+}
+
+// formatTable formats the data into a table with aligned columns
+func formatTable(data [][]string, msgs []string) string {
+	if len(data) != len(msgs) {
+		return ""
+	}
+
+	padLengths := calculatePadding(data)
+	var formattedRows []string
+
+	for row, rowData := range data {
+		var formattedCols []string
+		for col, colData := range rowData {
+			padding := strings.Repeat(" ", padLengths[col]-len(colData))
+
+			switch col {
+			case 2:
+				formattedCols = append(formattedCols, fmt.Sprintf("%s`%s%s`", discordEmojiIceCube, colData, padding))
+			case 3:
+				formattedCols = append(formattedCols, fmt.Sprintf("%s`%s%s`", discordEmojiDollar, colData, padding))
+			default:
+				formattedCols = append(formattedCols, fmt.Sprintf("`%s%s`", colData, padding))
+			}
+		}
+		formattedRows = append(formattedRows, discordEmojiSmallBlueDiamond+" "+strings.Join(formattedCols, " | "))
+
+		msg := msgs[row]
+		formattedRows = append(formattedRows, fmt.Sprintf("  \u21B3 %s", msg))
+	}
+
+	return strings.Join(formattedRows, "\n")
+}

--- a/pkg/model/icy.go
+++ b/pkg/model/icy.go
@@ -1,5 +1,7 @@
 package model
 
+import "time"
+
 // AdapterIcy is a struct response from adapter, before process to in-app model
 type AdapterIcy struct {
 	Data    []*Icy
@@ -43,4 +45,51 @@ type ContractInfo struct {
 	Name    string `json:"name"`
 	Address string `json:"address"`
 	Chain   string `json:"chain"`
+}
+
+type AdapterICYEarnedTransactions struct {
+	Data []*ICYEarnedTransaction `json:"data"`
+}
+
+type ICYEarnedTransaction struct {
+	ID                 string                 `json:"id"`
+	FromProfileID      string                 `json:"fromProfileID"`
+	OtherProfileID     string                 `json:"otherProfileID"`
+	FromProfileSource  string                 `json:"fromProfileSource"`
+	OtherProfileSource string                 `json:"otherProfileSource"`
+	SourcePlatform     string                 `json:"sourcePlatform"`
+	Amount             string                 `json:"amount"`
+	TokenID            string                 `json:"tokenID"`
+	ChainID            string                 `json:"chainID"`
+	InternalID         int64                  `json:"internalID"`
+	ExternalID         string                 `json:"externalID"`
+	OnchainTxHash      string                 `json:"onchainTxHash"`
+	Type               string                 `json:"type"`
+	Action             string                 `json:"action"`
+	Status             string                 `json:"status"`
+	CreatedAt          time.Time              `json:"createdAt"`
+	UpdatedAt          time.Time              `json:"updatedAt"`
+	ExpiredAt          *time.Time             `json:"expiredAt"`
+	SettledAt          *time.Time             `json:"settledAt"`
+	Token              *MochiToken            `json:"token"`
+	OriginalTxID       string                 `json:"originalTxID"`
+	OtherProfile       *MochiProfile          `json:"otherProfile"`
+	FromProfile        *MochiProfile          `json:"fromProfile"`
+	USDAmount          float64                `json:"usdAmount"`
+	Metadata           map[string]interface{} `json:"metadata"`
+	OtherProfileIds    []string               `json:"otherProfileIds"`
+	TotalAmount        string                 `json:"totalAmount"`
+	FromTokenId        string                 `json:"fromTokenId"`
+	ToTokenId          string                 `json:"toTokenId"`
+	FromAmount         string                 `json:"fromAmount"`
+	ToAmount           string                 `json:"toAmount"`
+}
+
+type AdapterICYTotalEarned struct {
+	Data *ICYTotalEarned `json:"data"`
+}
+
+type ICYTotalEarned struct {
+	TotalEarnsICY string `json:"totalEarnsICY"`
+	TotalEarnsUSD int64  `json:"totalEarnsUSD"`
 }

--- a/pkg/model/mochi.go
+++ b/pkg/model/mochi.go
@@ -1,0 +1,35 @@
+package model
+
+type MochiProfile struct {
+	ID                 string                    `json:"id"`
+	CreatedAt          string                    `json:"createdAt"`
+	UpdatedAt          string                    `json:"updatedAt"`
+	ProfileName        string                    `json:"profileName"`
+	Avatar             string                    `json:"avatar"`
+	AssociatedAccounts []MochiAssociatedAccounts `json:"associatedAccounts"`
+	Type               string                    `json:"type"`
+}
+
+type MochiAssociatedAccounts struct {
+	ID                 string      `json:"id"`
+	ProfileID          string      `json:"profileID"`
+	Platform           string      `json:"platform"`
+	PlatformIdentifier string      `json:"platformIdentifier"`
+	PlatformMetadata   interface{} `json:"platformMetadata"`
+	IsGuildMember      bool        `json:"isGuildMember"`
+	CreatedAt          string      `json:"createdAt"`
+	UpdatedAt          string      `json:"updatedAt"`
+}
+
+type MochiToken struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Symbol      string  `json:"symbol"`
+	Decimal     int64   `json:"decimal"`
+	ChainID     string  `json:"chainID"`
+	Native      bool    `json:"native"`
+	Address     string  `json:"address"`
+	Icon        string  `json:"icon"`
+	CoinGeckoID string  `json:"coinGeckoID"`
+	Price       float64 `json:"price"`
+}


### PR DESCRIPTION
#### What's this PR do?

Add implementation for cmd `?icy`, by this way, user can see their ICY related information such as total earned, earned txns.

<img width="401" alt="image" src="https://github.com/dwarvesf/fortress-discord/assets/32956772/3b34790a-6610-4171-8741-0a9850c126da">
<img width="401" alt="image" src="https://github.com/dwarvesf/fortress-discord/assets/32956772/e756ccb9-61cb-4ff3-92bc-866ac3eef053">
