### PR TITLE
fix: update cmd news to support lobsters

### DIFF
--- a/pkg/adapter/fortress/fortress.go
+++ b/pkg/adapter/fortress/fortress.go
@@ -1020,3 +1020,27 @@ func (f *Fortress) GetCommunityMemoEarn() (earns *model.AdapterMemoEarn, err err
 	}
 	return earns, nil
 }
+
+func (f *Fortress) FetchNews(platform, topic string) ([]model.News, []model.News, error) {
+	req, err := f.makeReq(fmt.Sprintf("/api/v1/news?platform=%s&topic=%s", platform, topic), http.MethodGet, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("invalid call, code %v", resp.StatusCode)
+	}
+
+	var news model.FetchNewsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&news); err != nil {
+		return nil, nil, fmt.Errorf("invalid decoded, error %v", err.Error())
+	}
+
+	return news.Data.Popular, news.Data.Emerging, nil
+}

--- a/pkg/adapter/fortress/interface.go
+++ b/pkg/adapter/fortress/interface.go
@@ -69,4 +69,6 @@ type FortressAdapter interface {
 	GetMemoOpenPullRequest() (memos *model.MemoPullRequestResponse, err error)
 
 	GetDiscordResearchTopics(page, size string) (data *model.DiscordResearchTopicResponse, err error)
+
+	FetchNews(platform, topic string) ([]model.News, []model.News, error)
 }

--- a/pkg/discord/command/news/base.go
+++ b/pkg/discord/command/news/base.go
@@ -10,25 +10,26 @@ func (c command) Prefix() []string {
 
 // Execute is where we handle logic for each command
 func (c command) Execute(message *model.DiscordMessage) error {
-	// default command for only 1 args input from user, c.g `?earn`
-	if len(message.ContentArgs) == 1 {
+	switch len(message.ContentArgs) {
+	case 1:
+		return c.DefaultCommand(message)
+	case 2:
+		switch message.ContentArgs[1] {
+		case "help":
+			return c.Help(message)
+		default:
+			return c.DefaultCommand(message)
+		}
+	case 3:
+		switch message.ContentArgs[1] {
+		case "reddit":
+			return c.Reddit(message, message.ContentArgs[2])
+		default:
+			return c.Fetch(message, message.ContentArgs[1], message.ContentArgs[2])
+		}
+	default:
 		return c.DefaultCommand(message)
 	}
-
-	// handle command for 2 args input from user, c.g `?earn list`
-	switch message.ContentArgs[1] {
-	case "help":
-		return c.Help(message)
-	case "reddit":
-		switch len(message.ContentArgs) {
-		case 2:
-			return c.DefaultCommand(message)
-		default:
-			return c.Reddit(message, message.ContentArgs[2])
-		}
-	}
-
-	return nil
 }
 
 func (c command) Name() string {

--- a/pkg/discord/command/news/fetch.go
+++ b/pkg/discord/command/news/fetch.go
@@ -1,0 +1,15 @@
+package news
+
+import "github.com/dwarvesf/fortress-discord/pkg/model"
+
+func (c command) Fetch(msg *model.DiscordMessage, platform, tag string) error {
+	logger := c.L.Field("func", "Lobsters")
+
+	popular, emerging, err := c.svc.News().Fetch(platform, tag)
+	if err != nil {
+		logger.Error(err, "failed to fetch Golang news")
+		return err
+	}
+
+	return c.view.News().Render(msg, platform, tag, popular, emerging)
+}

--- a/pkg/discord/command/news/reddit.go
+++ b/pkg/discord/command/news/reddit.go
@@ -13,10 +13,5 @@ func (c command) Reddit(msg *model.DiscordMessage, subreddit string) error {
 		return err
 	}
 
-	if len(popular) == 0 && len(emerging) == 0 {
-		logger.Info("no new Golang news")
-		return nil
-	}
-
 	return c.view.News().Reddit(msg, subreddit, popular, emerging)
 }

--- a/pkg/discord/service/news/fetch.go
+++ b/pkg/discord/service/news/fetch.go
@@ -1,0 +1,9 @@
+package news
+
+import (
+	"github.com/dwarvesf/fortress-discord/pkg/model"
+)
+
+func (c svc) Fetch(platform, topic string) ([]model.News, []model.News, error) {
+	return c.adapter.Fortress().FetchNews(platform, topic)
+}

--- a/pkg/discord/service/news/interface.go
+++ b/pkg/discord/service/news/interface.go
@@ -1,8 +1,14 @@
 package news
 
-import "github.com/vartanbeno/go-reddit/v2/reddit"
+import (
+	"github.com/dwarvesf/fortress-discord/pkg/model"
+	"github.com/vartanbeno/go-reddit/v2/reddit"
+)
 
 // Servicer is the interface for withdraw service
 type Servicer interface {
+	// TODO: update to use Fetch
 	Reddit(subreddit string) ([]reddit.Post, []reddit.Post, error)
+	// Fetch calls to fortress to get news by platform and topic, using for general.
+	Fetch(platform, topic string) ([]model.News, []model.News, error)
 }

--- a/pkg/discord/view/help/help.go
+++ b/pkg/discord/view/help/help.go
@@ -36,6 +36,7 @@ func (h *Help) Help(message *model.DiscordMessage) error {
 		// "**?memos**・list of Team memos",
 		"**?profile**・see dwarf profile",
 		// "**?mma**・manage MMA score",
+		"**?news**・get news from whitelisted platform",
 	}
 
 	msg := &discordgo.MessageEmbed{

--- a/pkg/discord/view/news/help.go
+++ b/pkg/discord/view/news/help.go
@@ -15,7 +15,8 @@ func (v view) Help(message *model.DiscordMessage) error {
 		"*Example*: `?news reddit golang`",
 		"",
 		"Currently supported platforms:",
-		"- [Reddit](https://www.reddit.com/)",
+		"- [Reddit](https://www.reddit.com/), check available topics [here](https://www.reddit.com/subreddits)",
+		"- [Lobsters](https://lobste.rs/), check available topics [here](https://lobste.rs/tags)",
 	}
 
 	msg := &discordgo.MessageEmbed{

--- a/pkg/discord/view/news/interface.go
+++ b/pkg/discord/view/news/interface.go
@@ -7,5 +7,6 @@ import (
 
 type Viewer interface {
 	Reddit(original *model.DiscordMessage, subreddit string, popular, emerging []reddit.Post) error
+	Render(original *model.DiscordMessage, platform, topic string, popular, emerging []model.News) error
 	Help(message *model.DiscordMessage) error
 }

--- a/pkg/discord/view/news/reddit.go
+++ b/pkg/discord/view/news/reddit.go
@@ -3,7 +3,6 @@ package news
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -42,26 +41,4 @@ func (v view) Reddit(original *model.DiscordMessage, subreddit string, popular, 
 	}
 
 	return base.SendEmbededMessage(v.ses, original, msg)
-}
-
-// timeAgo converts a time to a string representation of how long ago it was.
-func timeAgo(t time.Time) string {
-	now := time.Now()
-	duration := now.Sub(t)
-
-	if duration.Hours() >= 1 {
-		hours := int(duration.Hours())
-		return fmt.Sprintf("%d hour%s ago", hours, pluralize(hours))
-	} else {
-		minutes := int(duration.Minutes())
-		return fmt.Sprintf("%d minute%s ago", minutes, pluralize(minutes))
-	}
-}
-
-// Helper function to add 's' for pluralization.
-func pluralize(count int) string {
-	if count != 1 {
-		return "s"
-	}
-	return ""
 }

--- a/pkg/discord/view/news/render.go
+++ b/pkg/discord/view/news/render.go
@@ -1,0 +1,47 @@
+package news
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/dwarvesf/fortress-discord/pkg/discord/view/base"
+	"github.com/dwarvesf/fortress-discord/pkg/model"
+)
+
+// Render renders news message to Discord, using for any platform. Will migrate reddit later
+func (v view) Render(original *model.DiscordMessage, platform, topic string, popular, emerging []model.News) error {
+	content := make([]string, 0)
+
+	title := fmt.Sprintf("**<:pepe_ping:1028964391690965012> %s %s BUZZ!! <:pepe_ping:1028964391690965012>**", strings.ToUpper(platform), strings.ToUpper(topic))
+
+	if len(popular) > 0 {
+		content = append(content, "<a:badge5:1131851001117294672> **POPULAR**")
+		for _, post := range popular {
+			content = append(content, fmt.Sprintf("[[%v](%s)] %s", post.Popularity, post.URL, post.Title))
+		}
+		content = append(content, seeMore(platform, topic))
+	}
+
+	// Separate popular and emerging
+	content = append(content, "")
+
+	if len(emerging) > 0 {
+		content = append(content, "<a:arrow_up_animated:1131789319644921936> **EMERGING**")
+		for _, post := range emerging {
+			content = append(content, fmt.Sprintf("[[%s](%s)] %s", timeAgo(post.CreatedAt), post.URL, post.Title))
+		}
+		content = append(content, seeMore(platform, topic))
+	}
+
+	if len(popular) == 0 && len(emerging) == 0 {
+		content = append(content, "Oops! No posts found. Make sure your platform and topic are valid!")
+	}
+
+	msg := &discordgo.MessageEmbed{
+		Title:       title,
+		Description: strings.Join(content, "\n"),
+	}
+
+	return base.SendEmbededMessage(v.ses, original, msg)
+}

--- a/pkg/discord/view/news/utils.go
+++ b/pkg/discord/view/news/utils.go
@@ -1,0 +1,39 @@
+package news
+
+import (
+	"fmt"
+	"time"
+)
+
+// timeAgo converts a time to a string representation of how long ago it was.
+func timeAgo(t time.Time) string {
+	now := time.Now()
+	duration := now.Sub(t)
+
+	if duration.Hours() >= 1 {
+		hours := int(duration.Hours())
+		return fmt.Sprintf("%d hour%s ago", hours, pluralize(hours))
+	} else {
+		minutes := int(duration.Minutes())
+		return fmt.Sprintf("%d minute%s ago", minutes, pluralize(minutes))
+	}
+}
+
+// Helper function to add 's' for pluralization.
+func pluralize(count int) string {
+	if count != 1 {
+		return "s"
+	}
+	return ""
+}
+
+func seeMore(platform, topic string) string {
+	switch platform {
+	case "reddit":
+		return fmt.Sprintf("[See more...](https://www.reddit.com/r/%s/new/)\n", topic)
+	case "lobsters":
+		return fmt.Sprintf("[See more...](https://lobste.rs/t/%s)\n", topic)
+	default:
+		return ""
+	}
+}

--- a/pkg/model/news.go
+++ b/pkg/model/news.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+type News struct {
+	Title      string    `json:"title"`
+	URL        string    `json:"url"`
+	Popularity int64     `json:"popularity"`
+	CreatedAt  time.Time `json:"timestamp"`
+}
+
+type ListNews struct {
+	Popular  []News `json:"popular"`
+	Emerging []News `json:"emerging"`
+}
+
+type FetchNewsResponse struct {
+	Data ListNews `json:"data"`
+}


### PR DESCRIPTION
#### What's this PR do?

Update cmd `?news` to support [lobsters](https://lobste.rs/)

#### `?help`
![image](https://github.com/user-attachments/assets/1572e481-a599-4f58-b504-25efb9309c47)

#### `?news help`
![image](https://github.com/user-attachments/assets/a0fa10b1-dcdf-45c0-a24f-aeba680563c7)

#### `?news lobsters <topic>`
![image](https://github.com/user-attachments/assets/158ff2e4-cbef-4443-8e47-811aff42e70f)


